### PR TITLE
Nosetests config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+verbosity=3

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,6 @@
+def test_failing_test_fails():
+    assert False
+
+
+def test_passing_test_passes():
+    assert True


### PR DESCRIPTION
please merge https://github.com/NYU-DevOps-Squad-Wishlists/wishlists/pull/17 first, this PR used that as a base

```
(venv) ➜  wishlists git:(nosetests) ✗ nosetests tests
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
test_api.test_failing_test_fails ... FAIL
test_api.test_passing_test_passes ... ok

======================================================================
FAIL: test_api.test_failing_test_fails
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/billykern/Devel/wishlists/venv/lib/python3.9/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/billykern/Devel/wishlists/tests/test_api.py", line 2, in test_failing_test_fails
    assert False
AssertionError

----------------------------------------------------------------------
Ran 2 tests in 0.004s
```